### PR TITLE
fix: download jansson thirdparty

### DIFF
--- a/asterisk_modules/thirdparty/bootstrap
+++ b/asterisk_modules/thirdparty/bootstrap
@@ -4,4 +4,4 @@
 patch -p0 -i grpc-build.patch
 patch -p0 -i grpc-transport_fd_pipe.patch
 (git clone https://github.com/googleapis/googleapis.git -b common-protos-1_3_1 && cd googleapis && git submodule update --init --recursive)
-curl http://www.digip.org/jansson/releases/jansson-2.12.tar.gz|tar xz
+curl -L http://digip.org/jansson/releases/jansson-2.12.tar.gz|tar xz


### PR DESCRIPTION
`www.digip.org` get 302 with redirect on `digip.org`